### PR TITLE
Fix date display in search bar

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -123,23 +123,24 @@ export const Search: FC<SearchProps> = ({ onSearchResults }) => {
           htmlFor="arrivalTime"
           classnames="postOffer__label"
         >
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DateTimePicker
-              views={["day"]}
-              value={
-                offerFormData.departure_datetime.value
-                  ? dayjs(offerFormData.departure_datetime.value)
-                  : null
-              }
-              onChange={onDateChange}
-              minDate={dayjs()}
-              slotProps={{
-                textField: {
-                  sx: { width: "100%" },
-                },
-              }}
-            />
-          </LocalizationProvider>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <DateTimePicker
+                views={["day"]}
+                format="YYYY-MM-DD"
+                value={
+                  offerFormData.departure_datetime.value
+                    ? dayjs(offerFormData.departure_datetime.value)
+                    : null
+                }
+                onChange={onDateChange}
+                minDate={dayjs()}
+                slotProps={{
+                  textField: {
+                    sx: { width: "100%" },
+                  },
+                }}
+              />
+            </LocalizationProvider>
         </Label>
       </div>
 


### PR DESCRIPTION
## Summary
- show full date in the search bar DateTimePicker

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6875876b14b883328b7dd3aa39da1a18