### PR TITLE
Improve offer search UX

### DIFF
--- a/src/pages/search/SearchResult.tsx
+++ b/src/pages/search/SearchResult.tsx
@@ -5,21 +5,26 @@ import { Button } from "../../components/button/Button";
 import { Filter } from "../singleProductPage/Filter";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
-import { searchOffer, getAllOffers } from "../../api/route"; 
+import { searchOffer, getAllOffers } from "../../api/route";
+import { Loading } from "../../components/loading/Loading";
 
 export const SearchResult: FC = () => {
     const [isFilterOpened, setIsFilterOpened] = useState<boolean>(false);
-    const [searchResults, setSearchResults] = useState<any[]>([]); 
-    const [isSearching, setIsSearching] = useState<boolean>(false); 
+    const [searchResults, setSearchResults] = useState<any[]>([]);
+    const [isSearching, setIsSearching] = useState<boolean>(false);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
     const navigate = useNavigate();
 
     useEffect(() => {
         const fetchOffers = async () => {
+            setIsLoading(true);
             try {
-                const response = await getAllOffers(); 
-                setSearchResults(response.data); 
+                const response = await getAllOffers();
+                setSearchResults(response.data);
             } catch (error) {
                 console.error("Error fetching offers:", error);
+            } finally {
+                setIsLoading(false);
             }
         };
 
@@ -28,12 +33,15 @@ export const SearchResult: FC = () => {
 
     const handleSearchResults = async (searchParams: { origin_airport: string; destination_airport: string; takeoff_date: string }) => {
         setIsSearching(true);
+        setIsLoading(true);
 
         try {
             const response = await searchOffer(searchParams);
-            setSearchResults(response.data); 
+            setSearchResults(response.data);
         } catch (error) {
             console.error("Search Error:", error);
+        } finally {
+            setIsLoading(false);
         }
     };
 
@@ -62,10 +70,12 @@ export const SearchResult: FC = () => {
                         />
                     </div>
                     
-                    <div className="grid grid-cols-3 gap-[5.7rem]">
-                        {searchResults.length > 0 ? (
+                    <div className="grid grid-cols-3 gap-[5.7rem] min-h-[10rem]">
+                        {isLoading ? (
+                            <Loading />
+                        ) : searchResults.length > 0 ? (
                             searchResults.map((item, index) => (
-                                <OfferCard 
+                                <OfferCard
                                     key={index}
                                     secondaryButtonText={'View & Book'}
                                     onSecondaryClick={() => handlePrimaryButtonClick(item)}

--- a/src/pages/singleProductPage/SingleProductPage.scss
+++ b/src/pages/singleProductPage/SingleProductPage.scss
@@ -11,7 +11,7 @@
             padding: 24px 21px;
             border-bottom: 1px solid #D5D7DA;
             &__title {
-                font-size: 22px;
+                font-size: 16px;
                 font-weight: 500;
             }
         }
@@ -36,18 +36,18 @@
                     display: flex;
                     align-items: center;
                     gap: 20px;
-                    font-size: 22px;
+                    font-size: 16px;
                     font-weight: 400;
-                    line-height: 33px;
+                    line-height: 24px;
 
                     &__icon {
                         display: flex;
                     }
                 }
                 &__info {
-                    font-size: 22px;
+                    font-size: 16px;
                     font-weight: 400;
-                    line-height: 33px;
+                    line-height: 24px;
                 }
             }
         }
@@ -93,22 +93,22 @@
         &__content {
             padding: 25px 15px;
             &__item {
-                font-size: 22px;
+                font-size: 16px;
                 font-weight: 500;
                 margin-top: 12px;
             }
             &__itemTitle {
                 color: #999999;
             }
-            &__itemTotal {
-                margin-top: 32px;
-                padding-top: 32px;
-                border-top: 1px solid #B3B3B3;
-                font-size: 22px;
-                font-weight: 500;
-                &__title {
-                    color: #000;
-                }
+                &__itemTotal {
+                    margin-top: 32px;
+                    padding-top: 32px;
+                    border-top: 1px solid #B3B3B3;
+                    font-size: 16px;
+                    font-weight: 500;
+                    &__title {
+                        color: #000;
+                    }
             }
         }
     }

--- a/src/pages/singleProductPage/SingleProductPage.tsx
+++ b/src/pages/singleProductPage/SingleProductPage.tsx
@@ -23,6 +23,10 @@ export const SingleProductPage: FC = () => {
     const [comments, setComments] = useState<string | null>(null);
 
     useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
+    useEffect(() => {
         getSingleProduct(`${id}`).then(data => {
             setData(data.data.offer)
         })


### PR DESCRIPTION
## Summary
- show a spinner while offers load on the search results page
- scroll to top when opening an offer
- normalize font sizes on the offer details page

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68758788d45083328be6ff11b2304750