### PR TITLE
Fix search param mapping

### DIFF
--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -70,8 +70,8 @@ export const getUserDetails = async () => {
 };
 
 export const searchOffer = async (params: {
-  origin_airport: string;
-  destination_airport: string;
+  origin_airport: number;
+  destination_airport: number;
   takeoff_date: string;
 }) => {
   return await api.get(`/offers/search_offer/`, { params });

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -12,8 +12,8 @@ import { useState, useEffect } from "react";
 
 interface SearchProps {
   onSearchResults: (searchParams: {
-    origin_airport: string;
-    destination_airport: string;
+    origin_airport: number;
+    destination_airport: number;
     takeoff_date: string;
   }) => void;
 }
@@ -50,10 +50,15 @@ export const Search: FC<SearchProps> = ({ onSearchResults }) => {
     const { value } = event.target;
     if (!value) return;
 
+    const selectedAirport = airports.find(
+      (airport) => airport.airport_code === value
+    );
+    if (!selectedAirport) return;
+
     setOfferFormData((prevState) => ({
       ...prevState,
       [type === "to" ? "to_airport_id" : "from_airport_id"]: {
-        value,
+        value: selectedAirport.id,
         errorMessage: null,
       },
     }));
@@ -86,7 +91,7 @@ export const Search: FC<SearchProps> = ({ onSearchResults }) => {
   };
 
   const filteredToAirports = airports.filter(
-    (airport) => airport.airport_code !== offerFormData.from_airport_id.value
+    (airport) => airport.id !== offerFormData.from_airport_id.value
   );
 
   return (

--- a/src/pages/search/SearchResult.tsx
+++ b/src/pages/search/SearchResult.tsx
@@ -31,7 +31,7 @@ export const SearchResult: FC = () => {
         fetchOffers();
     }, []);
 
-    const handleSearchResults = async (searchParams: { origin_airport: string; destination_airport: string; takeoff_date: string }) => {
+    const handleSearchResults = async (searchParams: { origin_airport: number; destination_airport: number; takeoff_date: string }) => {
         setIsSearching(true);
         setIsLoading(true);
 


### PR DESCRIPTION
## Summary
- send airport IDs instead of codes in search form
- adjust search result types for numeric IDs
- update API helper to accept numeric IDs

## Testing
- `npm run build --silent`
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687be652969c8332947f02f50524f68c