### PR TITLE
Fix offer search query params

### DIFF
--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -70,8 +70,8 @@ export const getUserDetails = async () => {
 };
 
 export const searchOffer = async (params: {
-  origin_airport: number;
-  destination_airport: number;
+  origin_airport: string;
+  destination_airport: string;
   takeoff_date: string;
 }) => {
   return await api.get(`/offers/search_offer/`, { params });

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -12,8 +12,8 @@ import { useState, useEffect } from "react";
 
 interface SearchProps {
   onSearchResults: (searchParams: {
-    origin_airport: number;
-    destination_airport: number;
+    origin_airport: string;
+    destination_airport: string;
     takeoff_date: string;
   }) => void;
 }
@@ -58,7 +58,7 @@ export const Search: FC<SearchProps> = ({ onSearchResults }) => {
     setOfferFormData((prevState) => ({
       ...prevState,
       [type === "to" ? "to_airport_id" : "from_airport_id"]: {
-        value: selectedAirport.id,
+        value: selectedAirport.airport_code,
         errorMessage: null,
       },
     }));
@@ -91,7 +91,7 @@ export const Search: FC<SearchProps> = ({ onSearchResults }) => {
   };
 
   const filteredToAirports = airports.filter(
-    (airport) => airport.id !== offerFormData.from_airport_id.value
+    (airport) => airport.airport_code !== offerFormData.from_airport_id.value
   );
 
   return (

--- a/src/pages/search/SearchResult.tsx
+++ b/src/pages/search/SearchResult.tsx
@@ -31,7 +31,7 @@ export const SearchResult: FC = () => {
         fetchOffers();
     }, []);
 
-    const handleSearchResults = async (searchParams: { origin_airport: number; destination_airport: number; takeoff_date: string }) => {
+    const handleSearchResults = async (searchParams: { origin_airport: string; destination_airport: string; takeoff_date: string }) => {
         setIsSearching(true);
         setIsLoading(true);
 


### PR DESCRIPTION
## Summary
- fix searchOffer types to use airport codes
- update Search component to send airport codes
- adjust SearchResult parameter types

## Testing
- `npm run build --silent`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687bfe71d31483328dfa095c2c2f4e91