### PR TITLE
Fix search field defaults

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -8,6 +8,7 @@ type Props = {
   classnames?: string;
   options: { id: number; airport_name: string; airport_code: string }[];
   handleSelectChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  value?: string;
 };
 
 export const Select: FC<Props> = ({
@@ -17,12 +18,14 @@ export const Select: FC<Props> = ({
   classnames,
   options,
   handleSelectChange,
+  value,
 }) => {
   return (
     <select
       id={id}
       className={`select ${classnames ? classnames : ""}`}
       onChange={(event) => handleSelectChange(event)}
+      {...(value !== undefined ? { value } : {})}
     >
       <option value="" disabled defaultValue={""}>
         {placeholder}


### PR DESCRIPTION
## Summary
- ensure `Select` supports an optional `value` prop
- control `Search` inputs with state and initialize defaults
- keep origin/destination unique when selecting airports

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c059a69208332949d0367974ed6d4